### PR TITLE
Added reconnect logic

### DIFF
--- a/include/sick_safetyscanners/SickSafetyscanners.h
+++ b/include/sick_safetyscanners/SickSafetyscanners.h
@@ -44,6 +44,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <chrono>
 
 #include <sick_safetyscanners/communication/AsyncTCPClient.h>
 #include <sick_safetyscanners/communication/AsyncUDPClient.h>
@@ -97,7 +98,8 @@ public:
    */
   SickSafetyscanners(const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction,
                      sick::datastructure::CommSettings* settings,
-                     boost::asio::ip::address_v4 interface_ip);
+                     boost::asio::ip::address_v4 interface_ip,
+                     const std::chrono::duration<double> tcp_connect_timeout);
 
   /*!
    * \brief Destructor
@@ -207,6 +209,8 @@ private:
   std::shared_ptr<sick::cola2::Cola2Session> m_session_ptr;
 
   std::shared_ptr<sick::data_processing::UDPPacketMerger> m_packet_merger_ptr;
+
+  std::chrono::duration<double> m_tcp_connect_timeout;
 
   void processUDPPacket(const sick::datastructure::PacketBuffer& buffer);
   bool udpClientThread();

--- a/include/sick_safetyscanners/SickSafetyscannersRos.h
+++ b/include/sick_safetyscanners/SickSafetyscannersRos.h
@@ -147,7 +147,32 @@ private:
   ros::ServiceServer m_config_metadata_server;
   ros::ServiceServer m_status_overview_server;
 
-  bool m_initialised;
+  std::atomic_bool m_initialised;
+
+  /**
+   * @brief Configure Timer
+   */
+  ros::Timer m_configure_timer;
+
+  /**
+   * @brief Synchronization guard for watchdog variables accessed by ROS and lidar callbacks
+   */
+  std::mutex m_watchdog_mutex;
+
+  /**
+   * @brief Watchdog timer to reconnect if no sectors are received
+   */
+  ros::Timer m_scan_watchdog_timer;
+
+  /**
+   * @brief The last received scan sector timestamp
+   */
+  ros::Time m_scan_stamp;
+
+  /**
+   * @brief The last time the lidar was configured
+   */
+  ros::Time m_configured_stamp;
 
   std::shared_ptr<sick::SickSafetyscanners> m_device;
 
@@ -166,6 +191,15 @@ private:
   double m_timestamp_min_acceptable = -1.0;
   double m_timestamp_max_acceptable = 1.0;
   double m_min_intensities          = 0.0; /*!< min intensities for laser points */
+  /**
+   * @brief If no scan sectors have been received after this many seconds, reconnect to the lidar
+   */
+  ros::Duration m_scan_timeout { 5.0 };
+
+  /**
+   * @brief Period between lidar reconfiguration attempts
+   */
+  ros::Duration m_reconfiguration_timeout { 5.0 };
 
   bool m_use_sick_angles;
   float m_angle_offset;
@@ -250,6 +284,30 @@ private:
    * @return date string in the format YYYY-mm-DD HH:MM:SS
    */
   std::string getDateString(uint32_t days_since_1972, uint32_t milli_seconds);
+
+  /**
+   * @brief Connect and configure
+   *
+   * @return true if successfully connected
+   */
+  bool configure();
+
+  /**
+   * @brief Attempt to connect to and configure the lidar in response to a timer event
+   *
+   * @param[in] event - Timer event
+   */
+  void configureTimerCallback(const ros::TimerEvent& event);
+
+  /**
+   * @brief Check for scan outages timer callback
+   */
+  void scanWatchdogTimerCallback(const ros::TimerEvent& event);
+
+  /**
+   * @brief Trigger reconfigure routine
+   */
+  void triggerReconfigure();
 };
 
 } // namespace sick

--- a/include/sick_safetyscanners/SickSafetyscannersRos.h
+++ b/include/sick_safetyscanners/SickSafetyscannersRos.h
@@ -201,6 +201,11 @@ private:
    */
   ros::Duration m_reconfiguration_timeout { 5.0 };
 
+  /**
+   * @brief TCP connect timeout, in seconds
+   */
+  double m_tcp_connect_timeout { 5.0 };
+
   bool m_use_sick_angles;
   float m_angle_offset;
   bool m_use_pers_conf;

--- a/include/sick_safetyscanners/communication/AsyncTCPClient.h
+++ b/include/sick_safetyscanners/communication/AsyncTCPClient.h
@@ -89,7 +89,7 @@ public:
   /*!
    * \brief Establishes a connection from the host to the sensor.
    */
-  void doConnect();
+  bool doConnect(const std::chrono::seconds& wait_for_connect = std::chrono::seconds(-1));
 
   /*!
    * \brief Disconnects the host from the sensor
@@ -125,9 +125,6 @@ private:
   std::shared_ptr<boost::asio::ip::tcp::socket> m_socket_ptr;
   boost::asio::ip::tcp::endpoint m_remote_endpoint;
   std::thread m_service_thread;
-
-  boost::condition m_connect_condition;
-  boost::mutex m_connect_mutex;
   boost::mutex m_socket_mutex;
 
   void startReceive();

--- a/include/sick_safetyscanners/communication/AsyncTCPClient.h
+++ b/include/sick_safetyscanners/communication/AsyncTCPClient.h
@@ -89,7 +89,7 @@ public:
   /*!
    * \brief Establishes a connection from the host to the sensor.
    */
-  bool doConnect(const std::chrono::seconds& wait_for_connect = std::chrono::seconds(-1));
+  bool doConnect(const std::chrono::duration<double> wait_for_connect = std::chrono::duration<double>(-1.0));
 
   /*!
    * \brief Disconnects the host from the sensor

--- a/src/SickSafetyscanners.cpp
+++ b/src/SickSafetyscanners.cpp
@@ -40,8 +40,10 @@ namespace sick {
 SickSafetyscanners::SickSafetyscanners(
   const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction,
   sick::datastructure::CommSettings* settings,
-  boost::asio::ip::address_v4 interface_ip)
-  : m_newPacketReceivedCallbackFunction(newPacketReceivedCallbackFunction)
+  boost::asio::ip::address_v4 interface_ip,
+  const std::chrono::duration<double> tcp_connect_timeout) :
+  m_newPacketReceivedCallbackFunction(newPacketReceivedCallbackFunction),
+  m_tcp_connect_timeout(tcp_connect_timeout)
 {
   ROS_INFO("Starting SickSafetyscanners");
   m_io_service_ptr = std::make_shared<boost::asio::io_service>();
@@ -246,7 +248,7 @@ void SickSafetyscanners::startTCPConnection(const sick::datastructure::CommSetti
       settings.getSensorIp(),
       settings.getSensorTcpPort());
 
-  if (!async_tcp_client->doConnect())
+  if (!async_tcp_client->doConnect(m_tcp_connect_timeout))
   {
     std::stringstream ss;
     ss << "Could not connect to " << settings.getSensorIp() << " : " << settings.getSensorTcpPort() << "\n";

--- a/src/SickSafetyscanners.cpp
+++ b/src/SickSafetyscanners.cpp
@@ -245,7 +245,13 @@ void SickSafetyscanners::startTCPConnection(const sick::datastructure::CommSetti
       boost::ref(*m_io_service_ptr),
       settings.getSensorIp(),
       settings.getSensorTcpPort());
-  async_tcp_client->doConnect();
+
+  if (!async_tcp_client->doConnect())
+  {
+    std::stringstream ss;
+    ss << "Could not connect to " << settings.getSensorIp() << " : " << settings.getSensorTcpPort() << "\n";
+    throw std::runtime_error(ss.str());
+  }
 
   m_session_ptr.reset();
   m_session_ptr = std::make_shared<sick::cola2::Cola2Session>(async_tcp_client);

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -89,7 +89,7 @@ SickSafetyscannersRos::SickSafetyscannersRos()
 
   // Configure the lidar. On failure, start a timer to try again later.
   // TODO(carlos-m159): right now configure will always return true, even
-  // if socket creation fails. 
+  // if socket creation fails.
   if (!configure())
   {
     m_configure_timer.start();
@@ -974,31 +974,40 @@ void SickSafetyscannersRos::configureTimerCallback(const ros::TimerEvent& event)
 
 bool SickSafetyscannersRos::configure()
 {
-  m_device = std::make_shared<sick::SickSafetyscanners>(
-    boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1),
-    &m_communication_settings,
-    m_interface_ip);
-  m_device->run();
-  readTypeCodeSettings();
-
-  if (m_use_pers_conf)
+  try
   {
-    readPersistentConfig();
+    m_device = std::make_shared<sick::SickSafetyscanners>(
+      boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1),
+      &m_communication_settings,
+      m_interface_ip);
+    m_device->run();
+    readTypeCodeSettings();
+
+    if (m_use_pers_conf)
+    {
+      readPersistentConfig();
+    }
+
+    m_device->changeSensorSettings(m_communication_settings);
+    m_device->requestConfigMetadata(m_communication_settings, config_meta_data);
+    m_device->requestFirmwareVersion(m_communication_settings, firmware_version);
+
+    m_initialised = true;
+    {
+      std::lock_guard<std::mutex> lock(m_watchdog_mutex);
+      m_configured_stamp = ros::Time::now();
+    }
+    ROS_INFO("Successfully launched node.");
+  }
+  catch (const std::exception& e)
+  {
+    ROS_ERROR_STREAM("Error while configuring the lidar: " << e.what());
+    m_device.reset();
+    m_initialised = false;
   }
 
-  m_device->changeSensorSettings(m_communication_settings);
-  m_device->requestConfigMetadata(m_communication_settings, config_meta_data);
-  m_device->requestFirmwareVersion(m_communication_settings, firmware_version);
-
-  m_initialised = true;
-  {
-    std::lock_guard<std::mutex> lock(m_watchdog_mutex);
-    m_configured_stamp = ros::Time::now();
-  }
-  ROS_INFO("Successfully launched node.");
-  return true;
+  return m_initialised;
 }
-
 
 void SickSafetyscannersRos::triggerReconfigure()
 {

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -72,6 +72,10 @@ SickSafetyscannersRos::SickSafetyscannersRos()
   m_status_overview_server =
     m_nh.advertiseService("status_overview", &SickSafetyscannersRos::getStatusOverview, this);
 
+  m_scan_watchdog_timer = m_nh.createTimer(m_scan_timeout, &SickSafetyscannersRos::scanWatchdogTimerCallback, this);
+  m_configure_timer =
+		  m_nh.createTimer(m_reconfiguration_timeout, &SickSafetyscannersRos::configureTimerCallback, this, true, false);
+
   // Diagnostics for frequency
   m_diagnostic_updater.setHardwareID(m_communication_settings.getSensorIp().to_string());
 
@@ -83,24 +87,13 @@ SickSafetyscannersRos::SickSafetyscannersRos()
     m_laser_scan_publisher, m_diagnostic_updater, frequency_param, timestamp_param));
   m_diagnostic_updater.add("State", this, &SickSafetyscannersRos::sensorDiagnostics);
 
-  m_device = std::make_shared<sick::SickSafetyscanners>(
-    boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1),
-    &m_communication_settings,
-    m_interface_ip);
-  m_device->run();
-  readTypeCodeSettings();
-
-  if (m_use_pers_conf)
+  // Configure the lidar. On failure, start a timer to try again later.
+  // TODO(carlos-m159): right now configure will always return true, even
+  // if socket creation fails. 
+  if (!configure())
   {
-    readPersistentConfig();
+    m_configure_timer.start();
   }
-
-  m_device->changeSensorSettings(m_communication_settings);
-  m_device->requestConfigMetadata(m_communication_settings, config_meta_data);
-  m_device->requestFirmwareVersion(m_communication_settings, firmware_version);
-
-  m_initialised = true;
-  ROS_INFO("Successfully launched node.");
 }
 
 void SickSafetyscannersRos::readTypeCodeSettings()
@@ -261,6 +254,18 @@ bool SickSafetyscannersRos::readParameters()
 
   m_private_nh.getParam("min_intensities", m_min_intensities);
 
+  double scan_timeout = m_scan_timeout.toSec();
+  if (m_private_nh.param("scan_timeout", scan_timeout, scan_timeout))
+  {
+    m_scan_timeout = ros::Duration(scan_timeout);
+  }
+
+  double reconfiguration_timeout = m_reconfiguration_timeout.toSec();
+  if (m_private_nh.param("reconfiguration_timeout", reconfiguration_timeout, reconfiguration_timeout))
+  {
+    m_reconfiguration_timeout = ros::Duration(reconfiguration_timeout);
+  }
+
   return true;
 }
 
@@ -269,7 +274,11 @@ void SickSafetyscannersRos::receivedUDPPacket(const sick::datastructure::Data& d
   if (!data.getMeasurementDataPtr()->isEmpty() && !data.getDerivedValuesPtr()->isEmpty())
   {
     sensor_msgs::LaserScan scan = createLaserScanMessage(data);
-
+    {
+      // Update last received scan
+      std::lock_guard<std::mutex> lock(m_watchdog_mutex);
+      m_scan_stamp = scan.header.stamp;
+    }
     m_diagnosed_laser_scan_publisher->publish(scan);
   }
 
@@ -934,5 +943,71 @@ std::string SickSafetyscannersRos::getDateString(uint32_t days_since_1972, uint3
   return retval;
 }
 
+void SickSafetyscannersRos::scanWatchdogTimerCallback(const ros::TimerEvent& event)
+{
+  // If the timeout has expired, try to reconnect to the lidar
+  std::lock_guard<std::mutex> lock(m_watchdog_mutex);
+  auto elapsed_time = event.current_real - std::max(m_configured_stamp, m_scan_stamp);
+  if (m_initialised && elapsed_time > m_scan_timeout)
+  {
+    ROS_WARN_STREAM(
+      "No scan sector messages have been received in the last " << std::setprecision(3) << elapsed_time.toSec()
+                                                                << " seconds (since " << m_scan_stamp
+                                                                << "). Resetting the lidar.");
+    ROS_WARN_STREAM("Scan sector watchdog found an issue. Trying to reconnect to lidar.");
+    triggerReconfigure();
+  }
+}
+
+void SickSafetyscannersRos::configureTimerCallback(const ros::TimerEvent& event)
+{
+  // Stop the timer so that it may be restarted later
+  m_configure_timer.stop();
+
+  // Try to configure the lidar again
+  if (!m_initialised && !configure())
+  {
+    // Configuration failed. Restart the timer to try again.
+    m_configure_timer.start();
+  }
+}
+
+bool SickSafetyscannersRos::configure()
+{
+  m_device = std::make_shared<sick::SickSafetyscanners>(
+    boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1),
+    &m_communication_settings,
+    m_interface_ip);
+  m_device->run();
+  readTypeCodeSettings();
+
+  if (m_use_pers_conf)
+  {
+    readPersistentConfig();
+  }
+
+  m_device->changeSensorSettings(m_communication_settings);
+  m_device->requestConfigMetadata(m_communication_settings, config_meta_data);
+  m_device->requestFirmwareVersion(m_communication_settings, firmware_version);
+
+  m_initialised = true;
+  {
+    std::lock_guard<std::mutex> lock(m_watchdog_mutex);
+    m_configured_stamp = ros::Time::now();
+  }
+  ROS_INFO("Successfully launched node.");
+  return true;
+}
+
+
+void SickSafetyscannersRos::triggerReconfigure()
+{
+  // "disconnect"
+  m_device.reset();
+  // clean initialized state
+  m_initialised = false;
+  // Start reconfigure timer
+  m_configure_timer.start();
+}
 
 } // namespace sick

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -88,8 +88,6 @@ SickSafetyscannersRos::SickSafetyscannersRos()
   m_diagnostic_updater.add("State", this, &SickSafetyscannersRos::sensorDiagnostics);
 
   // Configure the lidar. On failure, start a timer to try again later.
-  // TODO(carlos-m159): right now configure will always return true, even
-  // if socket creation fails.
   if (!configure())
   {
     m_configure_timer.start();
@@ -265,6 +263,8 @@ bool SickSafetyscannersRos::readParameters()
   {
     m_reconfiguration_timeout = ros::Duration(reconfiguration_timeout);
   }
+
+  m_private_nh.param("tcp_connect_timeout", m_tcp_connect_timeout, m_tcp_connect_timeout);
 
   return true;
 }
@@ -946,13 +946,19 @@ std::string SickSafetyscannersRos::getDateString(uint32_t days_since_1972, uint3
 void SickSafetyscannersRos::scanWatchdogTimerCallback(const ros::TimerEvent& event)
 {
   // If the timeout has expired, try to reconnect to the lidar
-  std::lock_guard<std::mutex> lock(m_watchdog_mutex);
-  auto elapsed_time = event.current_real - std::max(m_configured_stamp, m_scan_stamp);
+  ros::Time configured_stamp;
+  ros::Time scan_stamp;
+  {
+    std::lock_guard<std::mutex> lock(m_watchdog_mutex);
+    configured_stamp = m_configured_stamp;
+    scan_stamp = m_scan_stamp;
+  }
+  auto elapsed_time = event.current_real - std::max(configured_stamp, scan_stamp);
   if (m_initialised && elapsed_time > m_scan_timeout)
   {
     ROS_WARN_STREAM(
       "No scan sector messages have been received in the last " << std::setprecision(3) << elapsed_time.toSec()
-                                                                << " seconds (since " << m_scan_stamp
+                                                                << " seconds (since " << scan_stamp
                                                                 << "). Resetting the lidar.");
     ROS_WARN_STREAM("Scan sector watchdog found an issue. Trying to reconnect to lidar.");
     triggerReconfigure();
@@ -979,7 +985,8 @@ bool SickSafetyscannersRos::configure()
     m_device = std::make_shared<sick::SickSafetyscanners>(
       boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1),
       &m_communication_settings,
-      m_interface_ip);
+      m_interface_ip,
+      std::chrono::duration<double>(m_tcp_connect_timeout));
     m_device->run();
     readTypeCodeSettings();
 
@@ -997,7 +1004,7 @@ bool SickSafetyscannersRos::configure()
       std::lock_guard<std::mutex> lock(m_watchdog_mutex);
       m_configured_stamp = ros::Time::now();
     }
-    ROS_INFO("Successfully launched node.");
+    ROS_INFO("Successfully configured lidar.");
   }
   catch (const std::exception& e)
   {

--- a/src/communication/AsyncTCPClient.cpp
+++ b/src/communication/AsyncTCPClient.cpp
@@ -85,23 +85,29 @@ void AsyncTCPClient::doDisconnect()
   }
 }
 
-void AsyncTCPClient::doConnect()
+bool AsyncTCPClient::doConnect(const std::chrono::seconds& wait_for_connect)
 {
   boost::mutex::scoped_lock lock(m_socket_mutex);
-  boost::mutex::scoped_lock lock_connect(m_connect_mutex);
-  m_socket_ptr->async_connect(m_remote_endpoint, [this](boost::system::error_code ec) {
-    if (ec != boost::system::errc::success)
+  auto connect_future = m_socket_ptr->async_connect(m_remote_endpoint, boost::asio::use_future);
+  if (wait_for_connect >= std::chrono::seconds(0))
+  {
+    if (std::future_status::ready != connect_future.wait_for(std::chrono::seconds(wait_for_connect)))
     {
-      ROS_ERROR("TCP error code: %i", ec.value());
+      ROS_ERROR_STREAM("Connect Timed out...");
+      return false;
     }
-    else
-    {
-      ROS_INFO("TCP connection successfully established.");
-    }
-    m_connect_condition.notify_all();
-  });
-
-  m_connect_condition.wait(lock_connect);
+  }
+  try
+  {
+    connect_future.get();
+    ROS_INFO("TCP connection successfully established.");
+  }
+  catch (const boost::system::system_error& error)
+  {
+    ROS_ERROR_STREAM("Failed to connect: " << error.what());
+    return false;
+  }
+  return true;
 }
 
 
@@ -147,7 +153,7 @@ void AsyncTCPClient::handleSendAndReceive(const boost::system::error_code& error
   }
   else
   {
-    ROS_ERROR("Error in tcp handle send and receive: %i", error.value());
+    ROS_ERROR_STREAM("Error in tcp handle send and receive: " << error.message());
   }
 }
 

--- a/src/communication/AsyncTCPClient.cpp
+++ b/src/communication/AsyncTCPClient.cpp
@@ -85,13 +85,13 @@ void AsyncTCPClient::doDisconnect()
   }
 }
 
-bool AsyncTCPClient::doConnect(const std::chrono::seconds& wait_for_connect)
+bool AsyncTCPClient::doConnect(const std::chrono::duration<double> wait_for_connect)
 {
   boost::mutex::scoped_lock lock(m_socket_mutex);
   auto connect_future = m_socket_ptr->async_connect(m_remote_endpoint, boost::asio::use_future);
   if (wait_for_connect >= std::chrono::seconds(0))
   {
-    if (std::future_status::ready != connect_future.wait_for(std::chrono::seconds(wait_for_connect)))
+    if (std::future_status::ready != connect_future.wait_for(wait_for_connect))
     {
       ROS_ERROR_STREAM("Connect Timed out...");
       return false;


### PR DESCRIPTION
- Added reconnection logic.
- Eliminated unnecessary mutex and condition variables previously employed for the connection, opting instead for a boost future.

This modification appears to successfully restore the lidars following power cycling during operation. While not ideal, querying potentially static data during each reconfiguration attempt was deemed a necessary compromise to minimize code changes.

⚠️ **Testing encompassed the following scenarios:**
 - Driver operational, power briefly interrupted: reconfiguration successfully reactivated the drivers.
 - Driver operational, lidar power disconnected for several minutes, then reconnected: initial reconfiguration attempts failed, but, once restored, succeeded.
 - Driver initializing with lidars powered off.
 
The impact of interrupting power during initial configuration ("CoLa session") remains untested.

```
CoLa 2 (Command Language 2) is a protocol from SICK, with
which a client (control, computer, etc.) can access suitable SICK
sensors via a network (TCP/IP) or USB.
```