### PR TITLE
Added function to get checksum value

### DIFF
--- a/include/sick_safetyscanners/SickSafetyscannersRos.h
+++ b/include/sick_safetyscanners/SickSafetyscannersRos.h
@@ -115,6 +115,8 @@ public:
    * the different laserscan outputs.
    */
   SickSafetyscannersRos();
+  SickSafetyscannersRos(bool getCheck);
+
 
   /*!
    * \brief ~SickSafetyscannersRos

--- a/launch/sick_safetyscanners.launch
+++ b/launch/sick_safetyscanners.launch
@@ -17,6 +17,7 @@
   <arg name="intrusion_data"        default="True" />
   <arg name="application_io_data"   default="True" />
   <arg name="use_persistent_config"   default="False" />
+  <arg name="get_crc"               default="False"/>
 
   <!-- Launch Sick SickSafetyscanners Ros Driver Node -->
   <node pkg="sick_safetyscanners" type="sick_safetyscanners_node" name="sick_safetyscanners" output="screen" ns="sick_safetyscanners">
@@ -38,6 +39,7 @@
      <param name="intrusion_data"         type="bool"   value="$(arg intrusion_data)" />
      <param name="application_io_data"    type="bool"   value="$(arg application_io_data)" />
      <param name="use_persistent_config"  type="bool"   value="$(arg use_persistent_config)" />
+     <param name="get_crc"                type="bool"   value="$(arg get_crc)" />
   </node>
 
 

--- a/nodes/sick_safetyscanners_node.cpp
+++ b/nodes/sick_safetyscanners_node.cpp
@@ -44,9 +44,16 @@
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "sick_safetyscanners");
+  ros::NodeHandle nh("~");
 
-  sick::SickSafetyscannersRos microscan3_ros;
+  bool get_crc = false; // Default value
+  nh.getParam("get_crc", get_crc);
+  if(get_crc) {
+    sick::SickSafetyscannersRos microscan3_ros(get_crc);
+  } else {
+    sick::SickSafetyscannersRos microscan3_ros;
+    ros::spin();
+  }
 
-  ros::spin();
   return 0;
 }

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -114,9 +114,10 @@ SickSafetyscannersRos::SickSafetyscannersRos(bool getCheck)
     m_nh.advertiseService("config_metadata", &SickSafetyscannersRos::getConfigMetadata, this);
 
   m_device = std::make_shared<sick::SickSafetyscanners>(
-    boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1),
-    &m_communication_settings,
-    m_interface_ip);
+      boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1),
+      &m_communication_settings,
+      m_interface_ip,
+      std::chrono::duration<double>(m_tcp_connect_timeout));
 
   m_device->run();
   m_device->requestConfigMetadata(m_communication_settings, config_meta_data);

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -94,6 +94,36 @@ SickSafetyscannersRos::SickSafetyscannersRos()
   }
 }
 
+SickSafetyscannersRos::SickSafetyscannersRos(bool getCheck)
+  : m_private_nh("~")
+  , m_initialised(false)
+  , m_time_offset(0.0)
+  , m_range_min(0.0)
+  , m_range_max(0.0)
+  , m_angle_offset(-90.0)
+  , m_use_pers_conf(false)
+{
+  if (!readParameters())
+  {
+    ROS_ERROR("Could not read parameters.");
+    ros::requestShutdown();
+  }
+  m_communication_settings.setSensorTcpPort(2122);
+
+  m_config_metadata_server =
+    m_nh.advertiseService("config_metadata", &SickSafetyscannersRos::getConfigMetadata, this);
+
+  m_device = std::make_shared<sick::SickSafetyscanners>(
+    boost::bind(&SickSafetyscannersRos::receivedUDPPacket, this, _1),
+    &m_communication_settings,
+    m_interface_ip);
+
+  m_device->run();
+  m_device->requestConfigMetadata(m_communication_settings, config_meta_data);
+
+  ROS_INFO_STREAM("Checksum: " + getCheckSumString(config_meta_data.getAppChecksum()));
+}
+
 void SickSafetyscannersRos::readTypeCodeSettings()
 {
   ROS_INFO("Reading Type code settings");
@@ -925,10 +955,14 @@ bool SickSafetyscannersRos::getStatusOverview(sick_safetyscanners::StatusOvervie
 std::string SickSafetyscannersRos::getCheckSumString(uint32_t checksum)
 {
   std::stringstream ss;
-  ss << "0x" << std::hex << (checksum & 0xFF) << ((checksum & 0xFF00) >> 8)
-     << ((checksum & 0xFF0000) >> 16) << ((checksum & 0xFF000000) >> 24);
+  ss << "0x" << std::hex
+     << ((checksum & 0xFF000000) >> 24)
+     << ((checksum & 0xFF0000) >> 16)
+     << ((checksum & 0xFF00) >> 8)
+     << (checksum & 0xFF);
   return ss.str();
 }
+
 
 std::string SickSafetyscannersRos::getDateString(uint32_t days_since_1972, uint32_t milli_seconds)
 {


### PR DESCRIPTION
Added a new constructor that only returns the CRC value when running the sick_safetyscanners node. It is triggerable by a get_crc parameter that defaults to false. I also added a small correction to their hex to string function that was returning the wrong values. 

[Screencast from 04-18-2024 11:25:27 AM.webm](https://github.com/locusrobotics/sick_safetyscanners/assets/144175590/8384a074-e5bf-4a97-bbb8-bf2fed12a251)
