### PR TITLE
Rst 9818 sick fieldset visualizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,11 @@ add_executable(${PROJECT_NAME}_node
   src/SickSafetyscannersRos.cpp
 )
 
+## Declare cpp executables
+add_executable(sick_viz
+  nodes/sick_viz.cpp
+)
+
 ## Add dependencies to exported targets, like ROS msgs or srvs
 add_dependencies(${PROJECT_NAME}_core
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
@@ -213,12 +218,22 @@ add_dependencies(${PROJECT_NAME}_node
   ${catkin_EXPORTED_TARGETS}
 )
 
+add_dependencies(sick_viz
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS}
+)
+
 ## Specify libraries to link executable targets against
 target_link_libraries(${PROJECT_NAME}_core
   ${catkin_LIBRARIES}
 )
 
 target_link_libraries(${PROJECT_NAME}_node
+  ${PROJECT_NAME}_core
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(sick_viz
   ${PROJECT_NAME}_core
   ${catkin_LIBRARIES}
 )
@@ -238,6 +253,13 @@ install(
 
 install(
   TARGETS ${PROJECT_NAME}_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(
+  TARGETS sick_viz
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,6 @@ add_executable(${PROJECT_NAME}_node
   src/SickSafetyscannersRos.cpp
 )
 
-## Declare cpp executables
 add_executable(sick_viz
   nodes/sick_viz.cpp
 )
@@ -219,7 +218,6 @@ add_dependencies(${PROJECT_NAME}_node
 )
 
 add_dependencies(sick_viz
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
   ${catkin_EXPORTED_TARGETS}
 )
 
@@ -234,7 +232,6 @@ target_link_libraries(${PROJECT_NAME}_node
 )
 
 target_link_libraries(sick_viz
-  ${PROJECT_NAME}_core
   ${catkin_LIBRARIES}
 )
 
@@ -260,8 +257,6 @@ install(
 
 install(
   TARGETS sick_viz
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
@@ -272,6 +267,13 @@ install(
   FILES_MATCHING
     PATTERN "*.h"
     PATTERN "*.hpp"
+)
+
+install(
+  DIRECTORY include/sick_viz/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING
+    PATTERN "*.h"
 )
 
 # Mark other files for installation

--- a/include/sick_viz/SickViz.h
+++ b/include/sick_viz/SickViz.h
@@ -1,0 +1,29 @@
+#ifndef SICK_SAFETYSCANNERS_SICKVIZ_H
+#define SICK_SAFETYSCANNERS_SICKVIZ_H
+
+#include "ros/ros.h"
+#include "sensor_msgs/LaserScan.h"
+#include "sick_safetyscanners/RawMicroScanDataMsg.h"
+#include "sick_safetyscanners/FieldData.h"
+#include "sick_safetyscanners/OutputPathsMsg.h"
+
+class SafetyFieldVisualizer {
+public:
+    SafetyFieldVisualizer(const std::string& robot, const std::string& laser, bool dtz = false);
+
+    void microscanCallback(const sick_safetyscanners::OutputPathsMsg::ConstPtr& msg);
+
+private:
+    ros::NodeHandle nh_;
+    ros::ServiceClient field_data_client_;
+    ros::Publisher safety_field_pub_;
+    ros::Subscriber raw_data_sub_;
+    sensor_msgs::LaserScan current_safety_field_;
+    std::string robot_;
+    std::string laser_;
+    bool dtz_;
+    std::string zone_type_;
+    sick_safetyscanners::FieldData field_data_;
+};
+
+#endif  // SICK_SAFETYSCANNERS_SICKVIZ_H

--- a/launch/sick_safetyscanners.launch
+++ b/launch/sick_safetyscanners.launch
@@ -18,9 +18,6 @@
   <arg name="application_io_data"   default="True" />
   <arg name="use_persistent_config"   default="False" />
   <arg name="get_crc"               default="False"/>
-  <arg name="use_viz"               default="False"/>
-  <arg name="robot_name"            default="$(optenv ROBOT robot)"/>
-
 
   <!-- Launch Sick SickSafetyscanners Ros Driver Node -->
   <node pkg="sick_safetyscanners" type="sick_safetyscanners_node" name="sick_safetyscanners" output="screen" ns="sick_safetyscanners">
@@ -45,8 +42,6 @@
      <param name="get_crc"                type="bool"   value="$(arg get_crc)" />
   </node>
 
-  <node pkg="sick_safetyscanners" type="sick_viz" name="sick_viz" output="screen" if="$(arg use_viz)">
-      <param name="robot_name" type="string" value="$(arg robot_name)"/>
-  </node>
-</launch>
 
+  <!-- node name="rqt_reconfigure" pkg="rqt_reconfigure" type="rqt_reconfigure" /-->
+</launch>

--- a/launch/sick_safetyscanners.launch
+++ b/launch/sick_safetyscanners.launch
@@ -18,6 +18,9 @@
   <arg name="application_io_data"   default="True" />
   <arg name="use_persistent_config"   default="False" />
   <arg name="get_crc"               default="False"/>
+  <arg name="use_viz"               default="False"/>
+  <arg name="robot_name"            default="$(optenv ROBOT robot)"/>
+
 
   <!-- Launch Sick SickSafetyscanners Ros Driver Node -->
   <node pkg="sick_safetyscanners" type="sick_safetyscanners_node" name="sick_safetyscanners" output="screen" ns="sick_safetyscanners">
@@ -42,7 +45,8 @@
      <param name="get_crc"                type="bool"   value="$(arg get_crc)" />
   </node>
 
-
-  <!-- node name="rqt_reconfigure" pkg="rqt_reconfigure" type="rqt_reconfigure" /-->
+  <node pkg="sick_safetyscanners" type="sick_viz" name="sick_viz" output="screen" if="$(arg use_viz)">
+      <param name="robot_name" type="string" value="$(arg robot_name)"/>
+  </node>
 </launch>
 

--- a/nodes/sick_viz.cpp
+++ b/nodes/sick_viz.cpp
@@ -6,21 +6,21 @@
 
 class SafetyFieldVisualizer {
 public:
-    SafetyFieldVisualizer(const std::string& robot, const std::string& laser, int augment = 0)
-        : robot_(robot), laser_(laser), augment_(augment) {
+    SafetyFieldVisualizer(const std::string& robot, const std::string& laser, bool dtz = false)
+        : robot_(robot), laser_(laser), dtz_(dtz) {
         // Wait for the service to get the field data
         ros::service::waitForService("/" + robot + "/" + laser + "_nanoscan/field_data", ros::Duration(5));
         field_data_client_ = nh_.serviceClient<sick_safetyscanners::FieldData>("/" + robot + "/" + laser + "_nanoscan/field_data");
         field_data_client_.call(field_data_);
-        zone_type_ = (augment) ? "protective":"DTZ";
+        zone_type_ = (dtz) ? "DTZ":"protective";
 
         ROS_INFO_STREAM("Number of fields: " << field_data_.response.fields.size());
         safety_field_pub_ = nh_.advertise
         <sensor_msgs::LaserScan>("/" + robot + "/" + laser + "_nanoscan/safety_field/" + zone_type_, 10);
         current_safety_field_.header.frame_id = robot + "/" + laser + "_laser_link";
-        current_safety_field_.angle_min = field_data_.response.fields[augment].start_angle;
-        current_safety_field_.angle_max = field_data_.response.fields[augment].start_angle + field_data_.response.fields[augment].angular_resolution * field_data_.response.fields[augment].ranges.size();
-        current_safety_field_.angle_increment = field_data_.response.fields[augment].angular_resolution;
+        current_safety_field_.angle_min = field_data_.response.fields[dtz].start_angle;
+        current_safety_field_.angle_max = field_data_.response.fields[dtz].start_angle + field_data_.response.fields[dtz].angular_resolution * field_data_.response.fields[dtz].ranges.size();
+        current_safety_field_.angle_increment = field_data_.response.fields[dtz].angular_resolution;
         // current_safety_field_.ranges = field_data.response.fields[augment].ranges;
         current_safety_field_.range_min = 0.01;
         current_safety_field_.range_max = 8.0;
@@ -31,7 +31,10 @@ public:
 
     void microscanCallback(const sick_safetyscanners::OutputPathsMsg::ConstPtr& msg) {
         current_safety_field_.header.stamp = ros::Time::now();
-        current_safety_field_.ranges = field_data_.response.fields[msg->active_monitoring_case + augment_].ranges;
+        current_safety_field_.ranges = field_data_.response.fields[field_data_.response.monitoring_cases[msg->active_monitoring_case].fields[dtz_]].ranges;
+        // current_safety_field_.ranges = field_data_.response.fields[0].ranges;
+        ROS_INFO_STREAM("Here: " << msg->active_monitoring_case);
+        ROS_INFO_STREAM("Here2: " << field_data_.response.monitoring_cases[msg->active_monitoring_case-1].fields[dtz_]);
         safety_field_pub_.publish(current_safety_field_);
     }
 
@@ -43,7 +46,7 @@ private:
     sensor_msgs::LaserScan current_safety_field_;
     std::string robot_;
     std::string laser_;
-    int augment_;
+    bool dtz_;
     std::string zone_type_;
     sick_safetyscanners::FieldData field_data_;
 };
@@ -51,13 +54,13 @@ private:
 int main(int argc, char** argv) {
     ros::init(argc, argv, "sick_viz");
 
-    std::string robot_name = "v2_19813";
-    SafetyFieldVisualizer left_protective(robot_name, "left");
-    SafetyFieldVisualizer right_protective(robot_name, "right");
-    SafetyFieldVisualizer rear_protective(robot_name, "rear");
-    SafetyFieldVisualizer left_DTZ(robot_name, "left", 1);
-    SafetyFieldVisualizer right_DTZ(robot_name, "right", 1);
-    SafetyFieldVisualizer rear_DTZ(robot_name, "rear", 1);
+    std::string robot_name = "v2_19811";
+    SafetyFieldVisualizer left_protective(robot_name, "left", false);
+    SafetyFieldVisualizer right_protective(robot_name, "right", false);
+    SafetyFieldVisualizer rear_protective(robot_name, "rear", false);
+    SafetyFieldVisualizer left_DTZ(robot_name, "left", true);
+    SafetyFieldVisualizer right_DTZ(robot_name, "right", true);
+    SafetyFieldVisualizer rear_DTZ(robot_name, "rear", true);
 
     ros::spin();
 

--- a/nodes/sick_viz.cpp
+++ b/nodes/sick_viz.cpp
@@ -1,7 +1,8 @@
 #include "ros/ros.h"
 #include "sensor_msgs/LaserScan.h"
-#include "sick_safetyscanners/RawMicroScanDataMsg.h"  // Include the correct message header
+#include "sick_safetyscanners/RawMicroScanDataMsg.h"  
 #include "sick_safetyscanners/FieldData.h"
+#include "sick_safetyscanners/OutputPathsMsg.h"
 
 class SafetyFieldVisualizer {
 public:
@@ -10,27 +11,27 @@ public:
         // Wait for the service to get the field data
         ros::service::waitForService("/" + robot + "/" + laser + "_nanoscan/field_data", ros::Duration(5));
         field_data_client_ = nh_.serviceClient<sick_safetyscanners::FieldData>("/" + robot + "/" + laser + "_nanoscan/field_data");
-        sick_safetyscanners::FieldData field_data;
-        field_data_client_.call(field_data);
+        field_data_client_.call(field_data_);
         zone_type_ = (augment) ? "protective":"DTZ";
 
-        ROS_INFO_STREAM("Number of fields: " << field_data.response.fields.size());
+        ROS_INFO_STREAM("Number of fields: " << field_data_.response.fields.size());
         safety_field_pub_ = nh_.advertise
-        <sensor_msgs::LaserScan>("/" + robot + "/" + laser + "_nanoscan/safety_field" + std::to_string(augment), 10);
+        <sensor_msgs::LaserScan>("/" + robot + "/" + laser + "_nanoscan/safety_field/" + zone_type_, 10);
         current_safety_field_.header.frame_id = robot + "/" + laser + "_laser_link";
-        current_safety_field_.angle_min = field_data.response.fields[augment].start_angle;
-        current_safety_field_.angle_max = field_data.response.fields[augment].start_angle + field_data.response.fields[augment].angular_resolution * field_data.response.fields[augment].ranges.size();
-        current_safety_field_.angle_increment = field_data.response.fields[augment].angular_resolution;
-        current_safety_field_.ranges = field_data.response.fields[augment].ranges;
+        current_safety_field_.angle_min = field_data_.response.fields[augment].start_angle;
+        current_safety_field_.angle_max = field_data_.response.fields[augment].start_angle + field_data_.response.fields[augment].angular_resolution * field_data_.response.fields[augment].ranges.size();
+        current_safety_field_.angle_increment = field_data_.response.fields[augment].angular_resolution;
+        // current_safety_field_.ranges = field_data.response.fields[augment].ranges;
         current_safety_field_.range_min = 0.01;
         current_safety_field_.range_max = 8.0;
 
         // Subscribe to the raw microscan data
-        raw_data_sub_ = nh_.subscribe("/" + robot + "/" + laser + "_nanoscan/raw_data", 1, &SafetyFieldVisualizer::microscanCallback, this);
+        raw_data_sub_ = nh_.subscribe("/" + robot + "/" + laser + "_nanoscan/output_paths", 1, &SafetyFieldVisualizer::microscanCallback, this);
     }
 
-    void microscanCallback(const sick_safetyscanners::RawMicroScanDataMsg::ConstPtr& msg) {
+    void microscanCallback(const sick_safetyscanners::OutputPathsMsg::ConstPtr& msg) {
         current_safety_field_.header.stamp = ros::Time::now();
+        current_safety_field_.ranges = field_data_.response.fields[msg->active_monitoring_case + augment_].ranges;
         safety_field_pub_.publish(current_safety_field_);
     }
 
@@ -38,18 +39,17 @@ private:
     ros::NodeHandle nh_;
     ros::ServiceClient field_data_client_;
     ros::Publisher safety_field_pub_;
-    ros::Subscriber raw_data_sub_;  // Declare raw data subscriber
+    ros::Subscriber raw_data_sub_;  
     sensor_msgs::LaserScan current_safety_field_;
     std::string robot_;
     std::string laser_;
     int augment_;
     std::string zone_type_;
-
+    sick_safetyscanners::FieldData field_data_;
 };
 
 int main(int argc, char** argv) {
     ros::init(argc, argv, "sick_viz");
-    ROS_INFO("Initialized Node");
 
     std::string robot_name = "v2_19813";
     SafetyFieldVisualizer left_protective(robot_name, "left");

--- a/nodes/sick_viz.cpp
+++ b/nodes/sick_viz.cpp
@@ -21,20 +21,17 @@ public:
         current_safety_field_.angle_min = field_data_.response.fields[dtz].start_angle;
         current_safety_field_.angle_max = field_data_.response.fields[dtz].start_angle + field_data_.response.fields[dtz].angular_resolution * field_data_.response.fields[dtz].ranges.size();
         current_safety_field_.angle_increment = field_data_.response.fields[dtz].angular_resolution;
-        // current_safety_field_.ranges = field_data.response.fields[augment].ranges;
         current_safety_field_.range_min = 0.01;
         current_safety_field_.range_max = 8.0;
 
-        // Subscribe to the raw microscan data
+        // Subscribe to the active monitoring case
         raw_data_sub_ = nh_.subscribe("/" + robot + "/" + laser + "_nanoscan/output_paths", 1, &SafetyFieldVisualizer::microscanCallback, this);
     }
 
     void microscanCallback(const sick_safetyscanners::OutputPathsMsg::ConstPtr& msg) {
         current_safety_field_.header.stamp = ros::Time::now();
-        current_safety_field_.ranges = field_data_.response.fields[field_data_.response.monitoring_cases[msg->active_monitoring_case].fields[dtz_]].ranges;
-        // current_safety_field_.ranges = field_data_.response.fields[0].ranges;
-        ROS_INFO_STREAM("Here: " << msg->active_monitoring_case);
-        ROS_INFO_STREAM("Here2: " << field_data_.response.monitoring_cases[msg->active_monitoring_case-1].fields[dtz_]);
+        current_safety_field_.ranges = field_data_.response.fields[field_data_.response.monitoring_cases[msg->active_monitoring_case-1].fields[dtz_]-1].ranges;
+      
         safety_field_pub_.publish(current_safety_field_);
     }
 
@@ -54,7 +51,7 @@ private:
 int main(int argc, char** argv) {
     ros::init(argc, argv, "sick_viz");
 
-    std::string robot_name = "v2_19811";
+    std::string robot_name = "v2_19814";
     SafetyFieldVisualizer left_protective(robot_name, "left", false);
     SafetyFieldVisualizer right_protective(robot_name, "right", false);
     SafetyFieldVisualizer rear_protective(robot_name, "rear", false);

--- a/nodes/sick_viz.cpp
+++ b/nodes/sick_viz.cpp
@@ -1,53 +1,35 @@
 #include "ros/ros.h"
-#include "sensor_msgs/LaserScan.h"
-#include "sick_safetyscanners/RawMicroScanDataMsg.h"  
-#include "sick_safetyscanners/FieldData.h"
-#include "sick_safetyscanners/OutputPathsMsg.h"
+#include "sick_viz/SickViz.h"
 
-class SafetyFieldVisualizer {
-public:
-    SafetyFieldVisualizer(const std::string& robot, const std::string& laser, bool dtz = false)
-        : robot_(robot), laser_(laser), dtz_(dtz) {
-        // Wait for the service to get the field data
-        ros::service::waitForService("/" + robot + "/" + laser + "_nanoscan/field_data", ros::Duration(5));
-        field_data_client_ = nh_.serviceClient<sick_safetyscanners::FieldData>("/" + robot + "/" + laser + "_nanoscan/field_data");
-        field_data_client_.call(field_data_);
-        zone_type_ = (dtz) ? "DTZ":"protective";
 
-        ROS_INFO_STREAM("Number of fields: " << field_data_.response.fields.size());
+SafetyFieldVisualizer::SafetyFieldVisualizer(const std::string& robot, const std::string& laser, bool dtz)
+    : robot_(robot), laser_(laser), dtz_(dtz) {
+    // Wait for the service to get the field data
+    ros::service::waitForService("/" + robot + "/" + laser + "_nanoscan/field_data", ros::Duration(5));
+    field_data_client_ = nh_.serviceClient<sick_safetyscanners::FieldData>("/" + robot + "/" + laser + "_nanoscan/field_data");
+    field_data_client_.call(field_data_);
+    zone_type_ = (dtz) ? "DTZ" : "protective";
 
-        safety_field_pub_ = nh_.advertise
-        <sensor_msgs::LaserScan>("/" + robot + "/" + laser + "_nanoscan/safety_field/" + zone_type_, 10);
-        current_safety_field_.header.frame_id = robot + "/" + laser + "_laser_link";
-        current_safety_field_.angle_min = field_data_.response.fields[dtz].start_angle;
-        current_safety_field_.angle_max = field_data_.response.fields[dtz].start_angle + field_data_.response.fields[dtz].angular_resolution * field_data_.response.fields[dtz].ranges.size();
-        current_safety_field_.angle_increment = field_data_.response.fields[dtz].angular_resolution;
-        current_safety_field_.range_min = 0.01;
-        current_safety_field_.range_max = 8.0;
+    ROS_INFO_STREAM("Number of fields: " << field_data_.response.fields.size());
 
-        // Subscribe to the active monitoring case topic
-        raw_data_sub_ = nh_.subscribe("/" + robot + "/" + laser + "_nanoscan/output_paths", 1, &SafetyFieldVisualizer::microscanCallback, this);
-    }
+    safety_field_pub_ = nh_.advertise<sensor_msgs::LaserScan>("/" + robot + "/" + laser + "_nanoscan/safety_field/" + zone_type_, 10);
+    current_safety_field_.header.frame_id = robot + "/" + laser + "_laser_link";
+    current_safety_field_.angle_min = field_data_.response.fields[dtz].start_angle;
+    current_safety_field_.angle_max = field_data_.response.fields[dtz].start_angle + field_data_.response.fields[dtz].angular_resolution * field_data_.response.fields[dtz].ranges.size();
+    current_safety_field_.angle_increment = field_data_.response.fields[dtz].angular_resolution;
+    current_safety_field_.range_min = 0.01;
+    current_safety_field_.range_max = 8.0;
 
-    void microscanCallback(const sick_safetyscanners::OutputPathsMsg::ConstPtr& msg) {
-        current_safety_field_.header.stamp = ros::Time::now();
-        current_safety_field_.ranges = field_data_.response.fields[field_data_.response.monitoring_cases[msg->active_monitoring_case-1].fields[dtz_]-1].ranges;
-      
-        safety_field_pub_.publish(current_safety_field_);
-    }
+    // Subscribe to the active monitoring case topic
+    raw_data_sub_ = nh_.subscribe("/" + robot + "/" + laser + "_nanoscan/output_paths", 1, &SafetyFieldVisualizer::microscanCallback, this);
+}
 
-private:
-    ros::NodeHandle nh_;
-    ros::ServiceClient field_data_client_;
-    ros::Publisher safety_field_pub_;
-    ros::Subscriber raw_data_sub_;  
-    sensor_msgs::LaserScan current_safety_field_;
-    std::string robot_;
-    std::string laser_;
-    bool dtz_;
-    std::string zone_type_;
-    sick_safetyscanners::FieldData field_data_;
-};
+void SafetyFieldVisualizer::microscanCallback(const sick_safetyscanners::OutputPathsMsg::ConstPtr& msg) {
+    current_safety_field_.header.stamp = ros::Time::now();
+    current_safety_field_.ranges = field_data_.response.fields[field_data_.response.monitoring_cases[msg->active_monitoring_case - 1].fields[dtz_]-1].ranges;
+
+    safety_field_pub_.publish(current_safety_field_);
+}
 
 int main(int argc, char** argv) {
     ros::init(argc, argv, "sick_viz");

--- a/nodes/sick_viz.cpp
+++ b/nodes/sick_viz.cpp
@@ -1,0 +1,65 @@
+#include "ros/ros.h"
+#include "sensor_msgs/LaserScan.h"
+#include "sick_safetyscanners/RawMicroScanDataMsg.h"  // Include the correct message header
+#include "sick_safetyscanners/FieldData.h"
+
+class SafetyFieldVisualizer {
+public:
+    SafetyFieldVisualizer(const std::string& robot, const std::string& laser, int augment = 0)
+        : robot_(robot), laser_(laser), augment_(augment) {
+        // Wait for the service to get the field data
+        ros::service::waitForService("/" + robot + "/" + laser + "_nanoscan/field_data", ros::Duration(5));
+        field_data_client_ = nh_.serviceClient<sick_safetyscanners::FieldData>("/" + robot + "/" + laser + "_nanoscan/field_data");
+        sick_safetyscanners::FieldData field_data;
+        field_data_client_.call(field_data);
+        zone_type_ = (augment) ? "protective":"DTZ";
+
+        ROS_INFO_STREAM("Number of fields: " << field_data.response.fields.size());
+        safety_field_pub_ = nh_.advertise
+        <sensor_msgs::LaserScan>("/" + robot + "/" + laser + "_nanoscan/safety_field" + std::to_string(augment), 10);
+        current_safety_field_.header.frame_id = robot + "/" + laser + "_laser_link";
+        current_safety_field_.angle_min = field_data.response.fields[augment].start_angle;
+        current_safety_field_.angle_max = field_data.response.fields[augment].start_angle + field_data.response.fields[augment].angular_resolution * field_data.response.fields[augment].ranges.size();
+        current_safety_field_.angle_increment = field_data.response.fields[augment].angular_resolution;
+        current_safety_field_.ranges = field_data.response.fields[augment].ranges;
+        current_safety_field_.range_min = 0.01;
+        current_safety_field_.range_max = 8.0;
+
+        // Subscribe to the raw microscan data
+        raw_data_sub_ = nh_.subscribe("/" + robot + "/" + laser + "_nanoscan/raw_data", 1, &SafetyFieldVisualizer::microscanCallback, this);
+    }
+
+    void microscanCallback(const sick_safetyscanners::RawMicroScanDataMsg::ConstPtr& msg) {
+        current_safety_field_.header.stamp = ros::Time::now();
+        safety_field_pub_.publish(current_safety_field_);
+    }
+
+private:
+    ros::NodeHandle nh_;
+    ros::ServiceClient field_data_client_;
+    ros::Publisher safety_field_pub_;
+    ros::Subscriber raw_data_sub_;  // Declare raw data subscriber
+    sensor_msgs::LaserScan current_safety_field_;
+    std::string robot_;
+    std::string laser_;
+    int augment_;
+    std::string zone_type_;
+
+};
+
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "sick_viz");
+    ROS_INFO("Initialized Node");
+
+    std::string robot_name = "v2_19813";
+    SafetyFieldVisualizer left_protective(robot_name, "left");
+    SafetyFieldVisualizer right_protective(robot_name, "right");
+    SafetyFieldVisualizer rear_protective(robot_name, "rear");
+    SafetyFieldVisualizer left_DTZ(robot_name, "left", 1);
+    SafetyFieldVisualizer right_DTZ(robot_name, "right", 1);
+    SafetyFieldVisualizer rear_DTZ(robot_name, "rear", 1);
+
+    ros::spin();
+
+    return 0;
+}

--- a/nodes/sick_viz.cpp
+++ b/nodes/sick_viz.cpp
@@ -28,7 +28,9 @@ void SafetyFieldVisualizer::microscanCallback(const sick_safetyscanners::OutputP
     current_safety_field_.header.stamp = ros::Time::now();
     current_safety_field_.ranges = field_data_.response.fields[field_data_.response.monitoring_cases[msg->active_monitoring_case - 1].fields[dtz_]-1].ranges;
 
-    safety_field_pub_.publish(current_safety_field_);
+    if (safety_field_pub_.getNumSubscribers() > 0) {
+        safety_field_pub_.publish(current_safety_field_);
+    }
 }
 
 int main(int argc, char** argv) {

--- a/nodes/sick_viz.cpp
+++ b/nodes/sick_viz.cpp
@@ -15,9 +15,24 @@ public:
         zone_type_ = (dtz) ? "DTZ":"protective";
 
         ROS_INFO_STREAM("Number of fields: " << field_data_.response.fields.size());
+
+        // Flipping fields right side up
+        // // ROS_INFO_STREAM("HERE" << field_data_.response.fields[dtz].ranges)
+        // for(int i = 0; i < field_data_.response.fields.size(); i++) {
+        //     // for(int j = 0; j < field_data_.response.fields[i].ranges.size(); j++){
+        //     //     field_data_.response.fields[i].ranges[j] = field_data_.response.fields[i].ranges[j];
+        //     // }
+        //     int size = field_data_.response.fields[i].ranges.size();
+        //     for (int j = 0; j < size / 2; ++j) {
+        //         int temp = field_data_.response.fields[i].ranges[j];
+        //         field_data_.response.fields[i].ranges[j] = field_data_.response.fields[i].ranges[size - 1 - j];
+        //         field_data_.response.fields[i].ranges[size - 1 - j] = temp;
+        //     }
+        // }
+
         safety_field_pub_ = nh_.advertise
         <sensor_msgs::LaserScan>("/" + robot + "/" + laser + "_nanoscan/safety_field/" + zone_type_, 10);
-        current_safety_field_.header.frame_id = robot + "/" + laser + "_laser_link";
+        current_safety_field_.header.frame_id = robot + "/" + laser + "_laser_link_flipped";
         current_safety_field_.angle_min = field_data_.response.fields[dtz].start_angle;
         current_safety_field_.angle_max = field_data_.response.fields[dtz].start_angle + field_data_.response.fields[dtz].angular_resolution * field_data_.response.fields[dtz].ranges.size();
         current_safety_field_.angle_increment = field_data_.response.fields[dtz].angular_resolution;

--- a/nodes/sick_viz.cpp
+++ b/nodes/sick_viz.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
     nh.getParam("laser_name", laser_name);
 
     SafetyFieldVisualizer protective(robot_name, laser_name, false);
-    SafetyFieldVisualizer left_DTZ(robot_name, laser_name, true);
+    SafetyFieldVisualizer DTZ(robot_name, laser_name, true);
 
     ros::spin();
 

--- a/nodes/sick_viz.cpp
+++ b/nodes/sick_viz.cpp
@@ -16,30 +16,16 @@ public:
 
         ROS_INFO_STREAM("Number of fields: " << field_data_.response.fields.size());
 
-        // Flipping fields right side up
-        // // ROS_INFO_STREAM("HERE" << field_data_.response.fields[dtz].ranges)
-        // for(int i = 0; i < field_data_.response.fields.size(); i++) {
-        //     // for(int j = 0; j < field_data_.response.fields[i].ranges.size(); j++){
-        //     //     field_data_.response.fields[i].ranges[j] = field_data_.response.fields[i].ranges[j];
-        //     // }
-        //     int size = field_data_.response.fields[i].ranges.size();
-        //     for (int j = 0; j < size / 2; ++j) {
-        //         int temp = field_data_.response.fields[i].ranges[j];
-        //         field_data_.response.fields[i].ranges[j] = field_data_.response.fields[i].ranges[size - 1 - j];
-        //         field_data_.response.fields[i].ranges[size - 1 - j] = temp;
-        //     }
-        // }
-
         safety_field_pub_ = nh_.advertise
         <sensor_msgs::LaserScan>("/" + robot + "/" + laser + "_nanoscan/safety_field/" + zone_type_, 10);
-        current_safety_field_.header.frame_id = robot + "/" + laser + "_laser_link_flipped";
+        current_safety_field_.header.frame_id = robot + "/" + laser + "_laser_link";
         current_safety_field_.angle_min = field_data_.response.fields[dtz].start_angle;
         current_safety_field_.angle_max = field_data_.response.fields[dtz].start_angle + field_data_.response.fields[dtz].angular_resolution * field_data_.response.fields[dtz].ranges.size();
         current_safety_field_.angle_increment = field_data_.response.fields[dtz].angular_resolution;
         current_safety_field_.range_min = 0.01;
         current_safety_field_.range_max = 8.0;
 
-        // Subscribe to the active monitoring case
+        // Subscribe to the active monitoring case topic
         raw_data_sub_ = nh_.subscribe("/" + robot + "/" + laser + "_nanoscan/output_paths", 1, &SafetyFieldVisualizer::microscanCallback, this);
     }
 
@@ -65,8 +51,10 @@ private:
 
 int main(int argc, char** argv) {
     ros::init(argc, argv, "sick_viz");
+    ros::NodeHandle nh("~");
 
-    std::string robot_name = "v2_19814";
+    std::string robot_name;
+    nh.getParam("robot_name", robot_name);
     SafetyFieldVisualizer left_protective(robot_name, "left", false);
     SafetyFieldVisualizer right_protective(robot_name, "right", false);
     SafetyFieldVisualizer rear_protective(robot_name, "rear", false);

--- a/nodes/sick_viz.cpp
+++ b/nodes/sick_viz.cpp
@@ -54,13 +54,13 @@ int main(int argc, char** argv) {
     ros::NodeHandle nh("~");
 
     std::string robot_name;
+    std::string laser_name;
+
     nh.getParam("robot_name", robot_name);
-    SafetyFieldVisualizer left_protective(robot_name, "left", false);
-    SafetyFieldVisualizer right_protective(robot_name, "right", false);
-    SafetyFieldVisualizer rear_protective(robot_name, "rear", false);
-    SafetyFieldVisualizer left_DTZ(robot_name, "left", true);
-    SafetyFieldVisualizer right_DTZ(robot_name, "right", true);
-    SafetyFieldVisualizer rear_DTZ(robot_name, "rear", true);
+    nh.getParam("laser_name", laser_name);
+
+    SafetyFieldVisualizer protective(robot_name, laser_name, false);
+    SafetyFieldVisualizer left_DTZ(robot_name, laser_name, true);
 
     ros::spin();
 


### PR DESCRIPTION
Added a visualizer node to the package. Automatic launch of the visualizer is added to [RST-9460-V2-nanoScan3-driver-integration](https://github.com/locusrobotics/locus_bots/tree/RST-9460-V2-nanoScan3-driver-integration)

[Screencast from 04-30-2024 01:39:31 PM.webm](https://github.com/locusrobotics/sick_safetyscanners/assets/144175590/c203e3bb-18f4-4834-95ba-5c3a88561e47)
