### PR TITLE
Fixed bad checksum return

### DIFF
--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -956,11 +956,11 @@ bool SickSafetyscannersRos::getStatusOverview(sick_safetyscanners::StatusOvervie
 std::string SickSafetyscannersRos::getCheckSumString(uint32_t checksum)
 {
   std::stringstream ss;
-  ss << "0x" << std::hex
-     << ((checksum & 0xFF000000) >> 24)
-     << ((checksum & 0xFF0000) >> 16)
-     << ((checksum & 0xFF00) >> 8)
-     << (checksum & 0xFF);
+  ss << "0x"
+     << std::setfill('0') << std::setw(2) << std::hex << ((checksum & 0xFF000000) >> 24)
+     << std::setfill('0') << std::setw(2) << std::hex << ((checksum & 0xFF0000) >> 16)
+     << std::setfill('0') << std::setw(2) << std::hex << ((checksum & 0xFF00) >> 8)
+     << std::setfill('0') << std::setw(2) << std::hex << (checksum & 0xFF);
   return ss.str();
 }
 


### PR DESCRIPTION
There was a bug in the get_checksum function where it would skip over 0s when translating from an int to a hex string. 

Before (see the checksum values):
![Screenshot from 2024-05-14 15-45-55](https://github.com/locusrobotics/sick_safetyscanners/assets/144175590/05ee397c-3a88-48d6-8de8-e8b909f0bc08)


After:
![Screenshot from 2024-05-14 15-43-47](https://github.com/locusrobotics/sick_safetyscanners/assets/144175590/8eab1769-243e-496c-b820-608b313de3ee)
