### PR TITLE
[RST-10411] Fix dynamic reconfigure crash

### DIFF
--- a/include/sick_safetyscanners/SickSafetyscannersRos.h
+++ b/include/sick_safetyscanners/SickSafetyscannersRos.h
@@ -137,6 +137,11 @@ private:
   ros::Publisher m_raw_data_publisher;
   ros::Publisher m_output_path_publisher;
 
+
+  dynamic_reconfigure::Server<sick_safetyscanners::SickSafetyscannersConfigurationConfig>
+    m_dynamic_reconfiguration_server;
+
+
   // Diagnostics
   diagnostic_updater::Updater m_diagnostic_updater;
   std::shared_ptr<DiagnosedLaserScanPublisher> m_diagnosed_laser_scan_publisher;
@@ -180,9 +185,6 @@ private:
 
   sick::datastructure::CommSettings m_communication_settings;
   boost::asio::ip::address_v4 m_interface_ip;
-
-  dynamic_reconfigure::Server<sick_safetyscanners::SickSafetyscannersConfigurationConfig>
-    m_dynamic_reconfiguration_server;
 
   std::string m_frame_id;
   double m_time_offset;

--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -41,6 +41,7 @@ namespace sick {
 SickSafetyscannersRos::SickSafetyscannersRos(const ros::NodeHandle &nodehandle)
   : m_nh(nodehandle)
   , m_private_nh(nodehandle)
+  , m_dynamic_reconfiguration_server(nodehandle)
   , m_initialised(false)
   , m_time_offset(0.0)
   , m_range_min(0.0)


### PR DESCRIPTION
- Fixes the crash when trying to change parameters in rqt
   - Added the private nodehandle to the dynamic_reconfigure server object
   - Changed the dynamic_reconfigure server object position in the `.h` due to initialization issues (compiler stuff)